### PR TITLE
Update build.bash

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -49,6 +49,8 @@ function ensure_package () {
   fi
 }
 
+ensure_package pkgconfig
+ensure_package libtool
 ensure_package glib
 
 if ! command -v autoreconf &> /dev/null; then


### PR DESCRIPTION
libtool and pkgconfig are required in the building process. For newly installed Homebrew, there would be errors without these two dependencies. 